### PR TITLE
fix filterNode

### DIFF
--- a/src/commonMain/kotlin/io/github/yuitosato/kotlintree/TreeNode.kt
+++ b/src/commonMain/kotlin/io/github/yuitosato/kotlintree/TreeNode.kt
@@ -218,12 +218,15 @@ class MutableTreeNode<T> private constructor(
         val initial: MutableTreeNode<T>? = null
         return foldNodeInternal(initial) { acc, treeNode, indices ->
             val condition = predicate(treeNode)
-            val newTreeNode = of(treeNode.value)
             when {
                 !condition -> acc
-                acc == null -> newTreeNode
+                indices.isEmpty() -> {
+                    val newTreeNode = of(treeNode.value)
+                    newTreeNode
+                }
                 else -> {
-                    acc.getOrNull(indices.take(indices.size - 1))
+                    val newTreeNode = of(treeNode.value)
+                    acc?.getOrNull(indices.take(indices.size - 1))
                         ?.children?.add(newTreeNode)
                     acc
                 }

--- a/src/commonMain/kotlin/io/github/yuitosato/kotlintree/TreeNode.kt
+++ b/src/commonMain/kotlin/io/github/yuitosato/kotlintree/TreeNode.kt
@@ -218,9 +218,10 @@ class MutableTreeNode<T> private constructor(
         val initial: MutableTreeNode<T>? = null
         return foldNodeInternal(initial) { acc, treeNode, indices ->
             val condition = predicate(treeNode)
+            val level = indices.size
             when {
                 !condition -> acc
-                indices.isEmpty() -> {
+                level == 0 -> {
                     val newTreeNode = of(treeNode.value)
                     newTreeNode
                 }

--- a/src/commonTest/kotlin/io/github/yuitosato/kotlintree/TreeNodeTest.kt
+++ b/src/commonTest/kotlin/io/github/yuitosato/kotlintree/TreeNodeTest.kt
@@ -241,7 +241,14 @@ class TreeNodeTest : FunSpec({
                 nodeOf(
                     11,
                     listOf(
-                        leafOf(111)
+                        nodeOf(
+                            111,
+                            listOf(
+                                leafOf(
+                                    0
+                                )
+                            )
+                        )
                     )
                 ),
                 leafOf(12),
@@ -275,10 +282,16 @@ class TreeNodeTest : FunSpec({
                 nodeOf(
                     11,
                     listOf(
-                        leafOf(111)
+                        nodeOf(
+                            0,
+                            listOf(
+                                leafOf(111),
+                                leafOf(-1)
+                            )
+                        )
                     )
                 ),
-                leafOf(12)
+                leafOf(-2)
             )
         )
 
@@ -294,7 +307,7 @@ class TreeNodeTest : FunSpec({
                 nodeOf(
                     11,
                     listOf(
-                        leafOf(111)
+                        nodeOf(111, listOf(leafOf(0)))
                     )
                 ),
                 leafOf(12),


### PR DESCRIPTION
Fixed a bug in the filterNode and filter methods of TreeNode, where filtering would not behave as intended when the root node does not meet the condition but some child nodes do.